### PR TITLE
Several fixes related to the management of home events

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/EventSubType.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/EventSubType.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.netatmo.internal.api.data;
 
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -21,29 +23,29 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public enum EventSubType {
-    SD_CARD_MISSING(EventType.SD, 1),
-    SD_CARD_INSERTED(EventType.SD, 2),
-    SD_CARD_FORMATTED(EventType.SD, 3),
-    SD_CARD_WORKING(EventType.SD, 4),
-    SD_CARD_DEFECTIVE(EventType.SD, 5),
-    SD_CARD_INCOMPATIBLE_SPEED(EventType.SD, 6),
-    SD_CARD_INSUFFICIENT_SPACE(EventType.SD, 7),
-    ALIM_INCORRECT_POWER(EventType.ALIM, 1),
-    ALIM_CORRECT_POWER(EventType.ALIM, 2),
+    SD_CARD_MISSING(List.of(EventType.SD), 1),
+    SD_CARD_INSERTED(List.of(EventType.SD), 2),
+    SD_CARD_FORMATTED(List.of(EventType.SD), 3),
+    SD_CARD_WORKING(List.of(EventType.SD), 4),
+    SD_CARD_DEFECTIVE(List.of(EventType.SD), 5),
+    SD_CARD_INCOMPATIBLE_SPEED(List.of(EventType.SD), 6),
+    SD_CARD_INSUFFICIENT_SPACE(List.of(EventType.SD), 7),
+    ALIM_INCORRECT_POWER(List.of(EventType.ALIM), 1),
+    ALIM_CORRECT_POWER(List.of(EventType.ALIM), 2),
 
     // Artificially implemented by the binding subtypes
-    PERSON_ARRIVAL(EventType.PERSON, 1),
-    PERSON_SEEN(EventType.PERSON, 2),
-    PERSON_DEPARTURE(EventType.PERSON_AWAY, 1),
-    MOVEMENT_HUMAN(EventType.MOVEMENT, 1),
-    MOVEMENT_VEHICLE(EventType.MOVEMENT, 2),
-    MOVEMENT_ANIMAL(EventType.MOVEMENT, 3);
+    PERSON_ARRIVAL(List.of(EventType.PERSON, EventType.PERSON_HOME), 1),
+    PERSON_SEEN(List.of(EventType.PERSON), 2),
+    PERSON_DEPARTURE(List.of(EventType.PERSON_AWAY), 1),
+    MOVEMENT_HUMAN(List.of(EventType.MOVEMENT, EventType.HUMAN), 1),
+    MOVEMENT_VEHICLE(List.of(EventType.MOVEMENT), 2),
+    MOVEMENT_ANIMAL(List.of(EventType.MOVEMENT, EventType.ANIMAL), 3);
 
-    public final EventType type;
+    public final List<EventType> types;
     public final int subType;
 
-    EventSubType(EventType type, int i) {
-        this.type = type;
+    EventSubType(List<EventType> types, int i) {
+        this.types = types;
         this.subType = i;
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/EventType.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/data/EventType.java
@@ -34,6 +34,9 @@ public enum EventType {
     @SerializedName("person_away") // When geofencing indicates that the person has left the home
     PERSON_AWAY(ModuleType.PERSON),
 
+    @SerializedName("person_home") // When the person is declared at home
+    PERSON_HOME(ModuleType.PERSON),
+
     @SerializedName("outdoor") // When the Outdoor Camera detects a human, a car or an animal
     OUTDOOR(ModuleType.PRESENCE, ModuleType.DOORBELL),
 
@@ -42,6 +45,12 @@ public enum EventType {
 
     @SerializedName("movement") // When the Indoor Camera detects motion
     MOVEMENT(ModuleType.WELCOME),
+
+    @SerializedName("human") // When the Indoor Camera detects human motion
+    HUMAN(ModuleType.WELCOME),
+
+    @SerializedName("animal") // When the Indoor Camera detects animal motion
+    ANIMAL(ModuleType.WELCOME),
 
     @SerializedName("new_module") // A new Module has been paired with the Indoor Camera
     NEW_MODULE(ModuleType.WELCOME),

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/Event.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/Event.java
@@ -58,7 +58,7 @@ public abstract class Event extends NAObject {
     }
 
     public Optional<EventSubType> getSubTypeDescription() {
-        return Stream.of(EventSubType.values()).filter(v -> v.type == getEventType() && v.subType == subType)
+        return Stream.of(EventSubType.values()).filter(v -> v.types.contains(getEventType()) && v.subType == subType)
                 .findFirst();
     }
 

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeEvent.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/api/dto/HomeEvent.java
@@ -67,8 +67,14 @@ public class HomeEvent extends Event {
         // Blend extra information provided by this kind of event in subcategories...
         if (type == EventType.PERSON) {
             subType = isArrival ? EventSubType.PERSON_ARRIVAL.subType : EventSubType.PERSON_SEEN.subType;
+        } else if (type == EventType.PERSON_HOME) {
+            subType = EventSubType.PERSON_ARRIVAL.subType;
         } else if (type == EventType.PERSON_AWAY) {
             subType = EventSubType.PERSON_DEPARTURE.subType;
+        } else if (type == EventType.HUMAN) {
+            subType = EventSubType.MOVEMENT_HUMAN.subType;
+        } else if (type == EventType.ANIMAL) {
+            subType = EventSubType.MOVEMENT_ANIMAL.subType;
         } else {
             switch (category) {
                 case ANIMAL:

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/HomeCapability.java
@@ -125,7 +125,9 @@ public class HomeCapability extends RestCapability<HomeApi> {
         } catch (NetatmoException e) {
             logger.warn("Error gettting Home informations : {}", e.getMessage());
         }
-        handler.getActiveChildren().forEach(handler -> result.addAll(handler.updateReadings()));
+        // Seems to trigger any HTTP request getevents for camera and person being called twice
+        // To be confirmed by Gael that this is ok to remove this call at this place and not at another
+        // handler.getActiveChildren().forEach(handler -> result.addAll(handler.updateReadings()));
         return result;
     }
 }

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/PersonCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/PersonCapability.java
@@ -16,6 +16,8 @@ import static org.openhab.binding.netatmo.internal.NetatmoBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -85,7 +87,20 @@ public class PersonCapability extends Capability {
         handler.getHomeCapability(SecurityCapability.class).ifPresent(cap -> {
             Collection<HomeEvent> events = cap.getPersonEvents(handler.getId());
             if (!events.isEmpty()) {
-                result.add(events.iterator().next());
+                // Get the most recent event
+                List<HomeEvent> listEvents = new ArrayList<>(events);
+                Collections.sort(listEvents, new Comparator<HomeEvent>() {
+                    @Override
+                    public int compare(HomeEvent o1, HomeEvent o2) {
+                        if (o1.getTime().isBefore(o2.getTime())) {
+                            return 1;
+                        } else if (o1.getTime().isAfter(o2.getTime())) {
+                            return -1;
+                        }
+                        return 0;
+                    }
+                });
+                result.add(listEvents.get(0));
             }
         });
         return result;

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/CameraChannelHelper.java
@@ -17,8 +17,6 @@ import static org.openhab.binding.netatmo.internal.utils.ChannelTypeUtils.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.netatmo.internal.api.dto.Event;
-import org.openhab.binding.netatmo.internal.api.dto.HomeEvent;
 import org.openhab.binding.netatmo.internal.api.dto.HomeStatusModule;
 import org.openhab.binding.netatmo.internal.api.dto.NAThing;
 import org.openhab.core.config.core.Configuration;
@@ -71,21 +69,6 @@ public class CameraChannelHelper extends ChannelHelper {
             }
         }
         return null;
-    }
-
-    @Override
-    protected @Nullable State internalGetEvent(String channelId, Event event) {
-        if (event instanceof HomeEvent && CHANNEL_EVENT_VIDEO_URL.equals(channelId)) {
-            HomeEvent homeEvent = (HomeEvent) event;
-            return toStringType(getStreamURL(homeEvent.getVideoId()));
-        }
-        return null;
-    }
-
-    private @Nullable String getStreamURL(@Nullable String videoId) {
-        String url = isLocal ? localUrl : vpnUrl;
-        return url == null || videoId == null ? null
-                : String.format("%s/vod/%s/index%s.m3u8", url, videoId, isLocal ? "_local" : "");
     }
 
     private @Nullable String getLivePictureURL() {

--- a/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.netatmo/src/main/resources/OH-INF/thing/channels.xml
@@ -316,8 +316,11 @@
 			<options>
 				<option value="PERSON">Face detected</option>
 				<option value="PERSON_AWAY">Person has left home</option>
+				<option value="PERSON_HOME">Person is at home</option>
 				<option value="OUTDOOR">Motion detected by Presence</option>
 				<option value="MOVEMENT">Motion detected</option>
+				<option value="HUMAN">Human seen</option>
+				<option value="ANIMAL">Animal seen</option>
 				<option value="NEW_MODULE">New Module has been paired</option>
 				<option value="MODULE_CONNECT">Module is connected with the Indoor Camera</option>
 				<option value="MODULE_DISCONNECT">Module lost its connection with the Indoor Camera</option>
@@ -366,8 +369,11 @@
 			<options>
 				<option value="PERSON"/>
 				<option value="PERSON_AWAY"/>
+				<option value="PERSON_HOME"/>
 				<option value="OUTDOOR"/>
 				<option value="MOVEMENT"/>
+				<option value="HUMAN"/>
+				<option value="ANIMAL"/>
 				<option value="NEW_MODULE"/>
 				<option value="MODULE_CONNECT"/>
 				<option value="MODULE_DISCONNECT"/>


### PR DESCRIPTION
New event types: HUMAN, ANIMAL, PERSON_HOME

Channel video-status set to NULL if no video attached to the event

Channel video-url set when a video is atteched to the event

Events sorted to get the most recent one

Avoid redundant calls to HTTP requests getevents for camero and person

Signed-off-by: Laurent Garnier <lg.hc@free.fr>