### PR TITLE
Ignore monitoring status when handling camera events

### DIFF
--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/capability/CameraCapability.java
@@ -76,8 +76,8 @@ public class CameraCapability extends Capability {
             localUrl = isLocal
                     ? handler.getHomeCapability(SecurityCapability.class).map(cap -> cap.ping(vpnUrl)).orElse(null)
                     : null;
-            cameraHelper.setUrls(vpnUrl, localUrl, OnOffType.ON.equals(newData.getMonitoring()));
-            eventHelper.setUrls(vpnUrl, localUrl, OnOffType.ON.equals(newData.getMonitoring()));
+            cameraHelper.setUrls(vpnUrl, localUrl);
+            eventHelper.setUrls(vpnUrl, localUrl);
         }
         if (!SdCardStatus.SD_CARD_WORKING.equals(newData.getSdStatus())
                 || !AlimentationStatus.ALIM_CORRECT_POWER.equals(newData.getAlimStatus())) {

--- a/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/EventChannelHelper.java
+++ b/bundles/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/handler/channelhelper/EventChannelHelper.java
@@ -34,7 +34,6 @@ public class EventChannelHelper extends ChannelHelper {
     private boolean isLocal;
     private @Nullable String vpnUrl;
     private @Nullable String localUrl;
-    private boolean isMonitoring;
 
     public EventChannelHelper() {
         this(GROUP_LAST_EVENT);
@@ -44,11 +43,10 @@ public class EventChannelHelper extends ChannelHelper {
         super(groupName);
     }
 
-    public void setUrls(String vpnUrl, @Nullable String localUrl, boolean isMonitoring) {
+    public void setUrls(String vpnUrl, @Nullable String localUrl) {
         this.localUrl = localUrl;
         this.vpnUrl = vpnUrl;
         this.isLocal = localUrl != null;
-        this.isMonitoring = isMonitoring;
     }
 
     @Override
@@ -87,7 +85,7 @@ public class EventChannelHelper extends ChannelHelper {
 
     private State getStreamURL(boolean local, @Nullable String videoId) {
         String url = local ? localUrl : vpnUrl;
-        if ((local && !isLocal) || url == null || videoId == null || !isMonitoring) {
+        if ((local && !isLocal) || url == null || videoId == null) {
             return UnDefType.NULL;
         }
         return toStringType("%s/vod/%s/index.m3u8", url, videoId);


### PR DESCRIPTION
Do not rely on call to setUrls to get the camera monitoring status
as it is called too late

Signed-off-by: Laurent Garnier <lg.hc@free.fr>